### PR TITLE
API v2.1 Preliminary Docs

### DIFF
--- a/doculab/docs/api-card-update.textile
+++ b/doculab/docs/api-card-update.textile
@@ -1,0 +1,43 @@
+Updating a Subscription’s Payment Profile with new information, or creating a new Payment Profile for a Subscription where none currently exists.  
+
+h2. Input Attributes
+
+In order for your request to be processed, you must set up Secure Parameters.  See "Chargify Direct Introduction - Secure Parameters":chargify-direct-introduction#secure-parameters for detailed information on how to authenticate requests to this endpoint.
+
+Note: the @subscription_id@ MUST be part of your @secure[data]@ parameter for the card update request to be processed.
+
+* @first_name@ (required) First name of the cardholder.
+* @last_name@ (required) Last name of the cardholder.
+* @card_number@ (required) The credit card number. 
+* @cvv@ (optional) The 3 or 4 digit card verification value. 
+* @expiration_month@ (required) The two-digit card expiration month.
+* @expiration_year@ (required) The four-digit card expiration year.
+
+The resource parameters are nested beneath a key named @payment_profile@, and are similar to the normal API inputs for the resource.
+
+<pre><code><form method="post" action="https://api.chargify.com/api/v2/subscriptions/<subscription.id>/card_update">
+  <!-- Secure parameters would go here here -->
+  <!-- For brevity, this form contains no labels, only inputs -->
+  <input type="text" name="payment_profile[first_name]" />
+  <input type="text" name="payment_profile[last_name]" />
+  <input type="text" name="payment_profile[card_number]" />
+  <input type="text" name="payment_profile[cvv]" />
+  <input type="text" name="payment_profile[expiration_month]" />
+  <input type="text" name="payment_profile[expiration_year]" />
+  <input type="submit" value="Update" />
+</form></code></pre>
+
+
+h2. Output Attributes
+
+When Chargify redirects back to your "redirect URI":chargify-direct-introduction#redirection-uri, it will include the following query-string parameters:
+
+* @api_id@ The API ID that made the original request
+* @timestamp@ The reflected or auto-generated timestamp
+* @nonce@ The reflected or auto-generated nonce
+* @status_code@ An HTTP status code that represents the status of the request
+* @result_code@ A Chargify-specific result code, that is related to the status code but may give more specific information about the result of your request
+* @call_id@ The ID for the stored representation of the original Call (form post). The Call may be fetched via the API for full response information (for both success and fail scenarios).
+* @signature@ The HMAC-SHA1 hexdigest of the previous parameters, to verify their integrity
+
+See "Response Signature":chargify-direct-introduction#response-parameters for more information about these attributes and what you can use them for.

--- a/doculab/docs/api-v21-introduction.textile
+++ b/doculab/docs/api-v21-introduction.textile
@@ -1,11 +1,10 @@
 The Chargify API allows you to interact with our system programmatically from your own application.
  
-The API attempts to conform to the "RESTful":http://en.wikipedia.org/wiki/Representational_State_Transfer design principles. You interact with the resources exposed via the API by accessing resource collection and element URIs using the HTTP verbs (GET, POST, PUT, and DELETE).  Chargify API v2.1 accepts JSON and form-encoded parameters, and returns JSON via the API.
+The API attempts to conform to the "RESTful":http://en.wikipedia.org/wiki/Representational_State_Transfer design principles. You interact with the resources exposed via the API by accessing resource collection and element URIs using the HTTP verbs (GET, POST, PUT, and DELETE).  Chargify API v2.1 accepts JSON and form-encoded parameters, and returns only JSON.
 
 h3. Authentication
 
 Authentication is implemented as HTTP Basic Authentication or OAuth over SSL (https), as described in "API Authentication":api-v21-authentication
-
 
 h3. URL
 
@@ -34,6 +33,6 @@ POST and PUT request data may be formatted as either FORM data (@application/x-w
 
 h3. Debugging
 
-If you're having difficulty executing a request via our API, try the simplest thing and attempt your request via the curl command-line tool, as shown in the below example.  Add the @--verbose@ flag to your request to receive even more debugging information.
+If you're having difficulty executing a request via our API, try the simplest thing and attempt your request via the curl command-line tool.  You can send a request to the "mirror":/api-v21-mirror endpoint to ensure you are authenticated, and that the parameters you are passing are formatted in the way you expect. Add the @--verbose@ flag to your request to receive even more debugging information.
 
 Another handy tool is "RequestBin":http://requestb.in/  You could create a RequestBin and send your request to them instead of us to see visually what it is you're sending, if you're not sure.

--- a/doculab/docs/api-v21-mirror.textile
+++ b/doculab/docs/api-v21-mirror.textile
@@ -5,7 +5,7 @@ h2. URI/Method
   
 h2. Mirror Input Attributes
 
-The mirror endpoint serves as a way of ensuring your API credentials are accepted by Chargify.
+The @/mirror@ endpoint serves as a way of ensuring your API credentials are valid, and also lets you inspect the parameters you are passing to the API.
 
 For @GET@ requests sent to @/mirror@, API v2.1 will return a @context@ object that will contain your @api_id@, and an @authenticated@ flag which will be @true@/@false@ based on whether your authentication credentials (either HTTP Auth or OAuth token) are valid.
 

--- a/doculab/docs/api-v21-resources.textile
+++ b/doculab/docs/api-v21-resources.textile
@@ -1,0 +1,4 @@
+|_. Resource/URI |_. GET |_. POST |_. PUT |_. DELETE |
+| Mirror<br/>@/mirror@ | Mirror API credentials | Mirror API credentials<br/>and request params | - | - |
+| Signups<br/>@/signups@ | - | Create new signup | - | - |
+ 

--- a/doculab/docs/api-v21-signups.textile
+++ b/doculab/docs/api-v21-signups.textile
@@ -1,0 +1,56 @@
+h2. URI/Method
+
+|_. Resource/URI |_. GET |_. POST |_. PUT |_. DELETE |
+| Signups<br/>@/signups@ | - | Create new signup | - | - |
+  
+h2. Signup Input Attributes
+
+When creating a signup, you must specify a @product@, @customer@, and @payment_profile@, all within the @signup@ key.  Credit card details may be required, depending on the options for the Product being subscribed (see "Product Options":/product-options).
+
+The product may be specified by either @product[id]@ or by @product[handle]@ (API Handle).
+
+* @product@ 
+** @id@ The id of the product your customer is signing up for
+** @handle@ The API handle of the product your customer is signing up for
+* @customer@
+** @first_name@ Customer's first name
+** @last_name@ Customer's last name
+** @email@ Customer's email address
+* @payment_profile@
+** @first_name@ First name on card
+** @last_name@ Last name on card
+** @card_number@ The full credit card number, as a string
+** @expiration_month@  The 1- or 2-digit credit card expiration month, as an integer or string, i.e. "5"
+** @expiration_year@  The 4-digit credit card expiration year, as an integer or string, i.e. "2012"
+
+h4. JSON for creating a signup with product[id]
+
+URL: @https://api.chargify.com/api/v2.1/signups@
+Method: @POST@
+
+<script src="http://gist.github.com/9c264cf848941775043d.js?file=signups-post-request-product-id.json"></script>
+
+h4. JSON for creating a signup with product[handle]
+
+URL: @https://api.chargify.com/api/v2.1/signups@
+Method: @POST@
+
+<script src="http://gist.github.com/9c264cf848941775043d.js?file=signups-post-request-product-handle.json"></script>
+
+h2. Signup Response
+
+The following is an example of a successful @POST@ to @/signups@
+
+<script src="http://gist.github.com/9c264cf848941775043d.js?file=signups-post-response.json"></script>
+
+h4. Unsuccessful responses
+
+Any errors will be returned within the @meta[errors]@ key. For example, when trying to create a new subscription without passing in the @payment_profile[expiration_month]@, the following is returned:
+
+<script src="http://gist.github.com/9c264cf848941775043d.js?file=signups-post-response-errors.json"></script>
+
+Not passing in a @customer@ at all will yield the following response:
+
+ <script src="http://gist.github.com/9c264cf848941775043d.js?file=signups-post-response-errors-customer.json"></script>
+
+

--- a/doculab/docs/chargify-direct-introduction.textile
+++ b/doculab/docs/chargify-direct-introduction.textile
@@ -171,6 +171,7 @@ Updating a Subscription's Payment Profile with new information.
 
 Resource URI: @https://api.chargify.com/api/v2/subscriptions/<subscription.id>/card_update@
 
+See "API: Card Update":api-card-update for more details.
 
 h2(#resource-parameters). Resource Parameters
 

--- a/doculab/meta/table_of_contents.rb
+++ b/doculab/meta/table_of_contents.rb
@@ -101,14 +101,17 @@ Doculab::TableOfContents.define do
   
   section "API v2 Resources" do
     page "API: Call"
+    page "API: Card Update"
   end
   
   section "API v2.1 Beta" do
     page "API v2.1 Introduction", permalink: "api-v21-introduction" 
+    page "API v2.1 Resources", permalink: "api-v21-resources"
   end
   
   section "API v2.1 Resources" do
     page "API v2.1 Mirror", permalink: "api-v21-mirror"  
+    page "API v2.1 Signups", permalink: "api-v21-signups"
   end
 
   section "3rd Party Integrations" do


### PR DESCRIPTION
Documentation includes `/mirror` and `/signups` endpoints as well as a general API v2.1 intro.

What is missing is an extended section on authentication (HTTP Basic and OAuth) but it will be fleshed out soon.

The users of this API will already know how to authenticate requests to these endpoints so I believe it is ok to release these docs now before we explicitly cover authentication for a wider audience.
