### PR TITLE
Copied refunds supported gateways from refunds doc

### DIFF
--- a/doculab/docs/api-refunds.textile
+++ b/doculab/docs/api-refunds.textile
@@ -1,4 +1,4 @@
-*Note: Refunds are currently only supported for the Authorize.Net gateway*
+*Note: Refunds are currently only supported for the Authorize.Net, Braintree, eWAY and Stripe gateways*
 
 With Chargify you have the ability to apply a refund to a payment that has been processed at the gateway. 
 


### PR DESCRIPTION
You guys will have to vet this but I noticed the supported gateways are different.

https://docs.chargify.com/refunds
https://docs.chargify.com/api-refunds
