### PR TITLE
[feature] Move return_url to public_signup_page.

### DIFF
--- a/doculab/docs/api-products.textile
+++ b/doculab/docs/api-products.textile
@@ -21,7 +21,6 @@ All of the product attribute fields are returned from GET (read) operations, and
 * @expiration_interval@ A numerical interval for the length a subscription to this product will run before it expires.   See the description of @interval@ for a description of how this value is coupled with an interval unit to calculate the full interval
 * @expiration_interval_unit@ A string representing the trial interval unit for this product, either @month@ or @day@
 * @version_number@ The version of the product
-* @return_url@ The URL a buyer is returned to after successful purchase.  See the section on "Return URLs and Parameters" [here](/product-options#return-url-and-parameters)
 * @return_params@ The parameters string we will use in constructing your return URL.  See the section on "Return URLs and Parameters" "here":/product-options#return-url-and-parameters
 * @require_credit_card@ Boolean
 * @request_credit_card@ Boolean
@@ -45,7 +44,6 @@ h2. Input Attributes (Create)
 * @trial_interval_unit@ A string representing the trial interval unit for this product, either @month@ or @day@
 * @expiration_interval@ A numerical interval for the length a subscription to this product will run before it expires.   See the description of @interval@ for a description of how this value is coupled with an interval unit to calculate the full interval
 * @expiration_interval_unit@ A string representing the trial interval unit for this product, either @month@ or @day@
-* @return_url@ The URL a buyer is returned to after successful purchase.  See the section on "Return URLs and Parameters" [here](/product-options#return-url-and-parameters)
 * @return_params@ The parameters string we will use in constructing your return URL.  See the section on "Return URLs and Parameters" "here":/product-options#return-url-and-parameters
 * @require_credit_card@ Boolean
 * @request_credit_card@ Boolean
@@ -397,7 +395,6 @@ Feature: Chargify API XML Product create
       <updated_at type="datetime">`auto generated`</updated_at>
       <request_credit_card type="boolean">true</request_credit_card>
       <require_credit_card type="boolean">true</require_credit_card>
-      <return_url nil="true"></return_url>
       <update_return_url nil="true"></update_return_url>
       <return_params nil="true"></return_params>
       <product_family>
@@ -410,6 +407,7 @@ Feature: Chargify API XML Product create
       <public_signup_pages type="array">
         <public_signup_page>
           <id type="integer">`auto generated`</id>
+          <return_url nil="true"></return_url>
           <url>`auto generated`</url>
         </public_signup_page>
       </public_signup_pages>
@@ -466,7 +464,6 @@ Feature: Chargify API JSON Product create
          "trial_interval_unit":null,
          "expiration_interval_unit":null,
          "expiration_interval":null,
-         "return_url":null,
          "update_return_url":null,
          "return_params":null,
          "require_credit_card":true,
@@ -484,6 +481,7 @@ Feature: Chargify API JSON Product create
          "public_signup_pages": [
           {
             "id": `auto generated`,
+            "return_url":null,
             "url": `auto generated`
           },
          "version_number": 1


### PR DESCRIPTION
https://trello.com/c/R58QslWe

Moved `return_url` to under `public_signup_page`.

Do we want to create a section for Public Signup Page attributes? In there, we'd link to https://docs.chargify.com/public-signup-page-settings#return-url for more info about the `return_url`.