### PR TITLE
Document 'full-price' component upgrade schemes

### DIFF
--- a/doculab/docs/api-allocations.textile
+++ b/doculab/docs/api-allocations.textile
@@ -16,7 +16,11 @@ The available 'upgrade' schemes are:
 
 * __prorate-delay-capture__: A charge is added for the prorated amount due, but the card is not charged until the subscription's next renewal
 
-* __prorate-attempt-capture__: A charge is added and  we attempt to charge the credit card on file.  If it fails, the charge will be accrued until the next renewal.
+* __prorate-attempt-capture__: A charge is added and we attempt to charge the credit card on file.  If it fails, the charge will be accrued until the next renewal.
+
+* __full-price-attempt-capture__: A charge is added for the full price of the component change, and we attempt to charge the credit card on file.  If it fails, the charge will be accrued until the next renewal.
+
+* __full-price-delay-capture__: A charge is added for the full price of the component change, but the card is not charged until the subscription's next renewal.
 
 * __no-prorate__: No charge is added.
 

--- a/doculab/docs/setting-component-allocations.textile
+++ b/doculab/docs/setting-component-allocations.textile
@@ -74,6 +74,10 @@ The available 'upgrade' schemes are:
 
 * __prorate-attempt-capture__: A charge is added and  we attempt to charge the credit card on file.  If it fails, the charge will be accrued until the next renewal.
 
+* __full-price-attempt-capture__: A charge is added for the full price of the component change, and we attempt to charge the credit card on file.  If it fails, the charge will be accrued until the next renewal.
+
+* __full-price-delay-capture__: A charge is added for the full price of the component change, but the card is not charged until the subscription's next renewal.
+
 * __no-prorate__: No charge is added.
 
 The available 'downgrade' schemes are:


### PR DESCRIPTION
Adds documentation for `full-price-attempt-capture` and `full-price-delay-capture` component upgrade schemes.