### PR TITLE
Extra characters in coupon codes.

### DIFF
--- a/doculab/docs/api-coupon-codes.textile
+++ b/doculab/docs/api-coupon-codes.textile
@@ -1,4 +1,4 @@
-Coupon subcodes can be administered in the Admin Interface or via the API.  
+Coupon subcodes can be administered in the Admin Interface or via the API.
 
 h2. URI/Method
 
@@ -65,7 +65,7 @@ Example response:
   "duplicate_codes" => [],
   "invalid_codes"   => ["50 OFF"]
 }
-</code></pre>    
+</code></pre>
 
 h2(#api-coupon-code-list). Retrieving Coupon Subcodes via the API
 
@@ -146,7 +146,7 @@ Example response:
   "duplicate_codes" => [],
   "invalid_codes"   => ["50 OFF"]
 }
-</code></pre>    
+</code></pre>
 
 h2(#api-coupon-code-delete). Deleting Coupon Subcodes via the API
 
@@ -155,5 +155,18 @@ Method: @DELETE@
 Required Parameters: coupon_id, and coupon subcode
 Response: If the coupon subcode is successfully removed, a '200' response code will be returned. Otherwise, a '404' error will be returned.
 
+*Note*: If you are using any of the allowed special characters ("%", "@", "+", "-", "_", and "."), you must encode them for use in the URL.
+
+|_. Special character |_. Encoding |
+| % | %25 |
+| @ | %40 |
+| + | %2B |
+| - | %2D |
+| _ | %5F |
+| . | %2E |
+
+
 Given a coupon with an @id@ of @567@, and a coupon subcode of @20OFF@, the URL to delete this coupon subcode would be: @@https://<subdomain>.chargify.com/coupons/567/codes/20OFF.<format>@
- 
+
+Or if the coupon subcode is @20%OFF@, the URL to delete this coupon subcode would be: @@https://<subdomain>.chargify.com/coupons/567/codes/20%25OFF.<format>@
+

--- a/doculab/docs/api-coupons.textile
+++ b/doculab/docs/api-coupons.textile
@@ -17,7 +17,7 @@ h2. Coupon Attributes
 When creating a coupon, you must specify a product family using the @product_family_id@. *If no @product_family_id@ is passed, the first product family available is used.* You will also need to formulate your URL to cite the Product Family ID in your request.
 
 * @name@ The internal coupon name. This information is never displayed to customers.
-* @code@ The coupon code. This is used by you or your customers to apply the coupon to a subscription.
+* @code@ The coupon code. This is used by you or your customers to apply the coupon to a subscription. The code may contain uppercase alphanumeric characters and these special characters (which allow for email addresses to be used): "%", "@", "+", "-", "_", and "."
 * @description@ The coupon description. This will be displayed to the customers after the coupon validation.
 * @percentage@ The discount percentage. Should be an integer between 1 and 100. You should set the percentage or the amount, but not both.
 * @amount@ Flat discount amount as a string with dollars and (optionally) cents, i.e. "10.00" for $10.00. You should set the percentage or the amount, but not both.


### PR DESCRIPTION
Specifically, allow "%", "@", "+", "-", "_", and "." so that email addresses can be used as coupon codes. (Applies to both codes and subcodes.)